### PR TITLE
Actually receive and process the status code

### DIFF
--- a/src/XmlResponse.php
+++ b/src/XmlResponse.php
@@ -107,7 +107,7 @@ class XmlResponse
      * @return mixed
      * @throws XmlResponseException
      */
-    public function array2xml($array, $xml = false, $headerAttribute = [])
+    public function array2xml($array, $xml = false, $headerAttribute = [], $status = 200)
     {
 
         if (is_object($array) && $array instanceof Arrayable) {
@@ -141,6 +141,6 @@ class XmlResponse
             }
         }
 
-        return Response::make($xml->asXML(), 200, $this->header());
+        return Response::make($xml->asXML(), $status, $this->header());
     }
 }

--- a/src/XmlResponseServiceProvider.php
+++ b/src/XmlResponseServiceProvider.php
@@ -14,8 +14,7 @@ class XmlResponseServiceProvider extends ServiceProvider
     public function register()
     {
         Response::macro('xml', function ($value, $status = 200, $headerTemplate = []) {
-            http_response_code($status);
-            return (new XmlResponse())->array2xml($value, false, $headerTemplate);
+            return (new XmlResponse())->array2xml($value, false, $headerTemplate, $status);
         });
     }
 


### PR DESCRIPTION
Previously, I was setting the status code, but that was being over-ridden because 200 was hard coded on the laravel response builder. I modified the xml response to accept a status code (default 200) and pass it to the response builder. I needed to be able to set the response code for errors and such.