### PR TITLE
fix internal numeric keys in XmlResponse.php

### DIFF
--- a/src/XmlResponse.php
+++ b/src/XmlResponse.php
@@ -171,7 +171,11 @@ class XmlResponse
                 $this->array2xml($value, $xml->addChild($this->caseSensitive((new \ReflectionClass(get_class($value)))->getShortName())));
             } else {
                 if (!is_null($value) || $this->showEmptyField) {
-                    $xml->addChild($this->caseSensitive($key), htmlspecialchars($value));
+                    if (is_numeric($key)) {
+                        $xml->addChild($this->caseSensitive('row_' . $key), htmlspecialchars($value));
+                    } else {
+                        $xml->addChild($this->caseSensitive($key), htmlspecialchars($value));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hi, i'm using your extension and just bumped into invalid markup, please test and would be great if you pulled this change in your repo.

Imbricated arrays with numeric keys resulted in invalid tags.
Sample array that failed (json_encode 'd): 
{  
   "current_page":1,
   "data":{  
      "0":{  
         "Topic_ID":1,
         "Forum_id":2,
      },
      "1":{  
         "Topic_ID":3,
         "Forum_id":4,
      },
      "debug":[  
         {  
            "info":"test",
            "params":[  
               "a",
               "b",
            ],
            "time":53.39
         }
      ]
   }
}