### PR TITLE
Private to protected variables for extending class

### DIFF
--- a/src/XmlResponse.php
+++ b/src/XmlResponse.php
@@ -16,27 +16,27 @@ class XmlResponse
     /**
      * @var
      */
-    private $caseSensitive;
+    protected $caseSensitive;
 
     /**
      * @var
      */
-    private $template;
+    protected $template;
 
     /**
      * @var
      */
-    private $showEmptyField;
+    protected $showEmptyField;
 
     /**
      * @var
      */
-    private $charset;
+    protected $charset;
 
     /**
      * @var
      */
-    private $rowName;
+    protected $rowName;
 
     /**
      * XmlResponse constructor.


### PR DESCRIPTION
Side step fix for: https://github.com/jailtonsc/laravel-response-xml/issues/17

`private` -> `protected` class variables which will allow class to be extended and take on its variables.